### PR TITLE
bump arrow version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [
     "crates/duckdb",
     "crates/libduckdb-sys",
-    "crates/duckdb-loadable-macros"
+    "crates/duckdb-loadable-macros",
 ]
 
 [workspace.package]
@@ -63,4 +63,4 @@ unicase = "2.6.0"
 url = "2.1"
 uuid = "1.0"
 vcpkg = "0.2"
-arrow = { version = "54.2.1", default-features = false }
+arrow = { version = "55", default-features = false }


### PR DESCRIPTION
mainly so we can bump our datafusion dependency in the main vortex repo.